### PR TITLE
Upgrade runtime base image from alpine:3.21 to alpine:3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY templates templates
 RUN go build -ldflags="-s -w" -o /usr/local/bin/server .
 
 # ── Runtime image ─────────────────────────────────────────────────────────────
-FROM alpine:3.21
+FROM alpine:3.22
 
 RUN apk add --no-cache ca-certificates tzdata
 


### PR DESCRIPTION
## Problem

The final runtime stage used `alpine:3.21` (released November 2024), which has been superseded by `alpine:3.22` (May 2025). Alpine 3.21 is missing security patches included in 3.22.

## Fix

```diff
-FROM alpine:3.21
+FROM alpine:3.22
```

Single-line bump. Non-root user and other hygiene were already in place.

## Testing

```bash
docker build -t distraction-test .
docker run --rm distraction-test id
# uid=1001(app) gid=65533(nogroup) ...
```

## Audit Note

**Reviewed**: Dockerfile, go.mod, main.go  
**Found & fixed**: outdated alpine:3.21 base image  
**Already good**: non-root user (app, UID 1001), multi-stage build, `go mod verify`  
**Skipped / future run**: `go.mod` declares `go 1.23.4` while most sibling repos are on `1.25`; worth bumping in a follow-up to pick up recent toolchain/security improvements
