### PR TITLE
Fix CORS bypass: set AllowCredentials=false when AllowedOrigins is wildcard

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,13 @@ func main() {
 	r.Use(secureMiddleware.Handler)
 
 	crs := cors.New(cors.Options{
-		AllowCredentials:   true,
+		// AllowCredentials must be false when AllowedOrigins is ["*"].
+		// Combining a wildcard origin with credentials causes go-chi/cors to
+		// reflect the incoming Origin header, allowing any site to make
+		// credentialed cross-origin requests (CORS bypass, CWE-942).
+		// distraction.today has no authentication and no endpoints that rely
+		// on cookies or session tokens, so credentials are not required.
+		AllowCredentials:   false,
 		OptionsPassthrough: false,
 		AllowedOrigins:     []string{"*"},
 		AllowedMethods:     []string{"GET", "POST", "OPTIONS"},

--- a/main.go
+++ b/main.go
@@ -66,12 +66,6 @@ func main() {
 	r.Use(secureMiddleware.Handler)
 
 	crs := cors.New(cors.Options{
-		// AllowCredentials must be false when AllowedOrigins is ["*"].
-		// Combining a wildcard origin with credentials causes go-chi/cors to
-		// reflect the incoming Origin header, allowing any site to make
-		// credentialed cross-origin requests (CORS bypass, CWE-942).
-		// distraction.today has no authentication and no endpoints that rely
-		// on cookies or session tokens, so credentials are not required.
 		AllowCredentials:   false,
 		OptionsPassthrough: false,
 		AllowedOrigins:     []string{"*"},


### PR DESCRIPTION
## Problem

`main.go` configures CORS with `AllowCredentials: true` and `AllowedOrigins: []string{"*"}`:

```go
// BEFORE (vulnerable)
crs := cors.New(cors.Options{
    AllowCredentials:   true,   // ← dangerous with wildcard origin
    AllowedOrigins:     []string{"*"},
    ...
})
```

When credentials are enabled, `go-chi/cors` reflects the incoming `Origin` header rather than responding with `*`. Any website can therefore make credentialed cross-origin requests to `distraction.today` (CORS bypass, CWE-942).

## Impact

`distraction.today` is a read-only, unauthenticated quote display site — no cookies, no sessions, no mutations. The concrete attack surface is minimal (information disclosure of quote data). However, the misconfiguration is clearly incorrect and should be corrected as security hygiene.

## Fix

Set `AllowCredentials: false`. No functional change.

## Audit note

**Reviewed:** `main.go`, `go.mod`, `Dockerfile`, `static/` package.

**Other findings (not fixed here):**
- `http.ListenAndServe` is used with no explicit server timeouts. Consider wrapping in `http.Server` with `ReadHeaderTimeout` etc.
- `go.mod` uses `go 1.24.0` with current dependencies.
- Templates are rendered via `render.New()` (backed by `html/template`) — no XSS risk.

**No existing `audit/` PR on this repo before this one.**
