### PR TITLE
fix: embed templates into binary

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"embed"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -18,6 +19,9 @@ import (
 	"github.com/unrolled/secure"
 )
 
+//go:embed templates
+var embeddedTemplates embed.FS
+
 const (
 	service = "distraction.today"
 	project = "icco-cloud"
@@ -32,6 +36,7 @@ var (
 		Extensions:                []string{".tmpl", ".html"},
 		RequirePartials:           false,
 		Funcs:                     []template.FuncMap{},
+		FileSystem:                &render.EmbedFileSystem{FS: embeddedTemplates},
 	})
 )
 


### PR DESCRIPTION
## Summary

- The recent multi-stage Dockerfile conversion (#25) only copies the compiled binary to the runtime image, leaving the `templates/` directory behind
- This caused `html/template: "404" is undefined` 500 errors on distraction.today
- Fix: use `//go:embed templates` to bundle templates into the binary itself

## Test plan

- [ ] CI builds and pushes new image
- [ ] Deploy to mist server: `docker compose pull distraction && docker compose up -d distraction`
- [ ] `curl https://distraction.today` returns 200 with HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)