### PR TITLE
fix: address golangci-lint findings

### DIFF
--- a/static/main.go
+++ b/static/main.go
@@ -1,3 +1,4 @@
+// Package static provides embedded daily quotes and helpers for accessing them.
 package static
 
 import (
@@ -54,6 +55,7 @@ func GetLatestQuote() (*Quote, error) {
 	return quotes[len(quotes)-1], nil
 }
 
+// GetQuotes returns all embedded quotes sorted by date ascending.
 func GetQuotes() ([]*Quote, error) {
 	file, err := fs.Open("quotes.json")
 	if err != nil {


### PR DESCRIPTION
## Summary
The new golangci-lint workflow added stricter linters. This PR fixes the findings so the lint check passes.

## Changes
- revive: added package comment for `static` and exported doc comment for `GetQuotes`.

## Verification
- `golangci-lint run -E bodyclose,misspell,gosec,errorlint,noctx,contextcheck,nilerr,wastedassign,unparam,copyloopvar,intrange,revive,gocritic,unconvert ./...` — 0 issues
- `go build ./...` — passes
- `go test ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)